### PR TITLE
ENH: Set default number of threads to 0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -110,7 +110,7 @@
 			"type": "boolean"
 		},
 		"num-threads": {
-			"default": 1,
+			"default": 0,
 			"description": "Maximum number of CPU threads to use. Set to 0 to use as many threads as there are cores",
 			"type": "integer"
 		},


### PR DESCRIPTION
This allows the gear to use all available cores.

This is undesirable in a HPC environment but in a gear, the container runs on a VM that
has been pre-allocated a fixed number of virtual cores. We can safely use all of them.